### PR TITLE
[b] Missing `python-dateutil` dependency in deployment mode

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "7 11 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - fix-date-util-dependency
 
 env:
   CI: true

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,9 +5,6 @@ on:
     # Set any time that you'd like scrapers to run (in UTC)
     - cron: "1 6 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - fix-date-util-dependency
 
 env:
   CI: true


### PR DESCRIPTION
## What's this PR do?
- Fix missing `python-dateutil` dependency in production mode.
- Related story: [DOC-933: Fix failed cron job of `city-scrapers-caconj`](https://linear.app/pdw/issue/DOC-933/fix-failed-cron-job-of-city-scrapers-caconj)

## Why are we doing this?
- Cron job is failing in combine_feed because of missing `python-dateutil`


![Screenshot 2025-02-17 at 14 31 27](https://github.com/user-attachments/assets/7605d7b2-f8aa-49b0-bc72-e4abb7105331)
![Screenshot 2025-02-17 at 14 31 41](https://github.com/user-attachments/assets/9bed4195-fed6-4a49-8806-9ffdb95f0a39)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a new dependency to enhance date handling capabilities.
  - Added a trigger for GitHub Actions workflows on push events for the `fix-date-util-dependency` branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->